### PR TITLE
Fixed en-us typo

### DIFF
--- a/src/langs/en-us.ts
+++ b/src/langs/en-us.ts
@@ -16,7 +16,7 @@ export default {
 
 	ABOUT_TITLE: 'About',
 	ABOUT_TEXT:
-		"Yo! My name is *-Erick-*||I'm a *-full stack developer-* mostly leaned towards the *-web-* development.||I love fiding my way around *-esquesite-* problems.||Meanwhile I also try my best to *-documentate-* the hardships that appeared along the *-journey-*.",
+		"Yo! My name is *-Erick-*||I'm a *-full stack developer-* mostly leaned towards the *-web-* development.||I love fiding my way around *-exquisite-* problems.||Meanwhile I also try my best to *-documentate-* the hardships that appeared along the *-journey-*.",
 
 	SPECIALTIES_TITLE: 'Specialties',
 	SPECIALTIES_MAIN_SKILL: 'Languages',


### PR DESCRIPTION
## Info

## Problems  

1. There is the word 'esquisite'.

## Fix

- [x] 1. Changed 'esquisite' to 'exquisite' at aed4d62b50071564679f53ee78966214c46ca2d4.