### PR TITLE
Introduced blog post update date

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ This is the Blob structure
 ```json
 [
     {
-        "id":     {BLOG_POST_ID}     [string],
-        "author": {BLOG_POST_AUTHOR} [string],
-        "theme":  {BLOG_POST_THEME}  [string],
-        "date":   {BLOG_POST_DATE}   [string] (YYYY-MM-DDTHH:MM:SSSZ),
+        "id":         {BLOG_POST_ID}     [string],
+        "author":     {BLOG_POST_AUTHOR} [string],
+        "theme":      {BLOG_POST_THEME}  [string],
+        "date":       {BLOG_POST_DATE}   [string] (YYYY-MM-DDTHH:MM:SSSZ),
+        "updateDate": {BLOG_POST_DATE}   [string] (YYYY-MM-DDTHH:MM:SSSZ),
         "title": {
             {LOCALE}: {TEXT} [string]
         },

--- a/src/app/[lang]/sitemap.ts
+++ b/src/app/[lang]/sitemap.ts
@@ -83,7 +83,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
                 const blogSitemap = {
                     url: `${url}/${path}`,
-                    lastModified: post.date,
+                    lastModified: post.updateDate ?? post.date,
                     alternates: {
                         languages: getAlternates(baseUrl, path),
                     },

--- a/src/utils/interfaces/blog.ts
+++ b/src/utils/interfaces/blog.ts
@@ -6,6 +6,7 @@ export interface Blog {
     author: string;
     theme: string;
     date: string;
+    updateDate?: string;
     status: 'RELEASED' | 'UPCOMING';
     title: Dictionary;
     description: Dictionary;


### PR DESCRIPTION
## Info

Sometimes there are changes made to the blog post after release, but the `date` being the only property being used to both represent release date and update date is not ideal, so I've introduced the `updateDate` property.
